### PR TITLE
Jsx force multiline attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prettier",
+  "name": "@logicsoftware/prettier",
   "version": "2.5.0-dev",
   "description": "Prettier is an opinionated code formatter",
   "bin": "./bin/prettier.js",

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -20,7 +20,7 @@ const {
   utils: { willBreak },
 } = require("../../document/index.js");
 
-const { getLast, getPreferredQuote } = require("../../common/util.js");
+const { getLast, getPreferredQuote, isNonEmptyArray } = require("../../common/util.js");
 const {
   isJsxNode,
   rawText,
@@ -596,7 +596,7 @@ function printJsxOpeningElement(path, options, print) {
 
   // We should print the opening element expanded if any prop value is a
   // string literal with newlines
-  const shouldBreak =
+  const hasMultilineStringAttr =
     node.attributes &&
     node.attributes.some(
       (attr) =>
@@ -604,6 +604,13 @@ function printJsxOpeningElement(path, options, print) {
         isStringLiteral(attr.value) &&
         attr.value.value.includes("\n")
     );
+
+  const isFirstAttrOnTheNextLine =
+    isNonEmptyArray(node.attributes) &&
+    node.attributes.length > 1 &&
+    node.attributes[0].loc.start.line !== node.loc.start.line;
+
+  const shouldBreak = hasMultilineStringAttr || isFirstAttrOnTheNextLine;
 
   return group(
     [

--- a/tests/format/jsx/split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -36,6 +36,20 @@ short_open =
     hello
   </BaseForm>
 
+short_forced_new_line =
+  <BaseForm
+    url="/auth/google"
+    method="GET">
+    hello
+  </BaseForm>
+
+no_new_line_if_there_is_only_one_attribute =
+  <BaseForm
+    url="/auth/google"
+  >
+    hello
+  </BaseForm>
+
 make_self_closing =
   <div>
     <BaseForm url="/auth/google" method="GET" colour="blue" size="large" submitLabel="Sign in with Google">
@@ -165,6 +179,19 @@ short_open = (
   <BaseForm url="/auth/google" method="GET">
     hello
   </BaseForm>
+);
+
+short_forced_new_line = (
+  <BaseForm
+    url="/auth/google"
+    method="GET"
+  >
+    hello
+  </BaseForm>
+);
+
+no_new_line_if_there_is_only_one_attribute = (
+  <BaseForm url="/auth/google">hello</BaseForm>
 );
 
 make_self_closing = (

--- a/tests/format/jsx/split-attrs/test.js
+++ b/tests/format/jsx/split-attrs/test.js
@@ -28,6 +28,20 @@ short_open =
     hello
   </BaseForm>
 
+short_forced_new_line =
+  <BaseForm
+    url="/auth/google"
+    method="GET">
+    hello
+  </BaseForm>
+
+no_new_line_if_there_is_only_one_attribute =
+  <BaseForm
+    url="/auth/google"
+  >
+    hello
+  </BaseForm>
+
 make_self_closing =
   <div>
     <BaseForm url="/auth/google" method="GET" colour="blue" size="large" submitLabel="Sign in with Google">


### PR DESCRIPTION
allow forcing multiline jsx attributes (if first attribute is moved to the new line then save multiline mode)

example
```
<MyComponent 
    a1={1} a2={2}
/>
```

will be formatted as
```
<MyComponent
   a1={1}
   a2={2]
/>   
```
_________
but

```
<MyComponent a1={1} a2={2} />

// or

<MyComponent a1={1} 
     a2={2} />
```

will be formatted as (if there is enough space by print-width option)
```
<MyComponent a1={1} a2={2} />   
```
